### PR TITLE
Override paypal-sdk-core ca_file setting

### DIFF
--- a/lib/spree_paypal_express/engine.rb
+++ b/lib/spree_paypal_express/engine.rb
@@ -22,5 +22,21 @@ module SpreePaypalExpress
     initializer "spree.paypal_express.payment_methods", :after => "spree.register.payment_methods" do |app|
       app.config.spree.payment_methods << Spree::Gateway::PayPalExpress
     end
+
+    # Fixes the issue about some PayPal requests failing with
+    # OpenSSL::SSL::SSLError (SSL_connect returned=1 errno=0 state=error: certificate verify failed)
+    module CAFileHack
+      # This overrides paypal-sdk-core default so we don't pass the cert the gem provides to the
+      # NET::HTTP instance. This way we rely on the default behavior of validating the server's cert
+      # against the CA certs of the OS (we assume), which tend to be up to date.
+      #
+      # See https://github.com/openfoodfoundation/openfoodnetwork/issues/5855 for details.
+      def default_ca_file
+        nil
+      end
+    end
+
+    require 'paypal-sdk-merchant'
+    ::PayPal::SDK::Core::Util::HTTPHelper.prepend(CAFileHack)
   end
 end


### PR DESCRIPTION
This skips the Net::HTTP `ca_file` option so it doesn't specify that gem's `data/paypal.crt` file which is 8 years old and it's not longer valid to verify the PayPal server's SSL cert. This is likely due to https://nakedsecurity.sophos.com/2020/07/13/digicert-revokes-a-raft-of-web-security-certificates/.